### PR TITLE
eigen: Switch checker to HTML

### DIFF
--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -199,8 +199,9 @@
                     "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz",
                     "sha256": "8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
                     "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 13751,
+                        "type": "html",
+                        "url": "https://eigen.tuxfamily.org/index.php?title=Main_Page",
+                        "version-pattern": "latest stable release</b> is Eigen ([\\d\\.-]+[\\d])",
                         "stable-only": true,
                         "url-template": "https://gitlab.com/libeigen/eigen/-/archive/$version/eigen-$version.tar.gz"
                     }


### PR DESCRIPTION
Switch from Anitya to HTML as `release-monitoring.org` has its peculiarities, and seeing that the HTML check can work, then just switch it.